### PR TITLE
Mention the bot to use as a prefix

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -1,20 +1,32 @@
 const client = require("../index");
 
 client.on("messageCreate", async (message) => {
-    if (
-        message.author.bot ||
-        !message.guild ||
-        !message.content.toLowerCase().startsWith(client.config.prefix)
-    )
-        return;
+  const mentionRegex = RegExp(`^<@!?${client.user.id}>$`);
+  const mentionRegexPrefix = RegExp(`^<@!?${client.user.id}> `);
 
-    const [cmd, ...args] = message.content
-        .slice(client.config.prefix.length)
-        .trim()
-        .split(" ");
+  let prefix = message.content.match(mentionRegexPrefix)
+    ? message.content.match(mentionRegexPrefix)[0]
+    : client.config.prefix;
 
-    const command = client.commands.get(cmd.toLowerCase()) || client.commands.find(c => c.aliases?.includes(cmd.toLowerCase()));
+  if (message.content.match(mentionRegex))
+    message.channel.send(
+      `My prefix for ${message.guild.name} is \`${prefix}\`.`
+    );
 
-    if (!command) return;
-    await command.run(client, message, args);
+  if (
+    message.author.bot ||
+    !message.guild ||
+    !message.content.toLowerCase().startsWith(prefix)
+  )
+    return;
+
+  const [cmd, ...args] = message.content.slice(prefix.length).trim().split(" ");
+
+  const command =
+    client.commands.get(cmd.toLowerCase()) ||
+    client.commands.find((c) => c.aliases?.includes(cmd.toLowerCase()));
+
+  if (!command) return;
+  await command.run(client, message, args);
 });
+


### PR DESCRIPTION
You can mention the bot instead using a prefix like `@bot ping`.
Also if you just ping the bot it returns the actual prefix for the server (you can configure the bot to have different prefixes on each server either by saving the prefix to the database or caching it in memory)