### PR TITLE
Fix splitting arguments

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -11,7 +11,7 @@ client.on("messageCreate", async (message) => {
     const [cmd, ...args] = message.content
         .slice(client.config.prefix.length)
         .trim()
-        .split(" ");
+        .split(/ +/g);
 
     const command = client.commands.get(cmd.toLowerCase()) || client.commands.find(c => c.aliases?.includes(cmd.toLowerCase()));
 


### PR DESCRIPTION
Using a regular expression is wiser since you can have multiple white spaces between the arguments.
I hope you find this useful