### PR TITLE
Put return after the )

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -5,8 +5,7 @@ client.on("messageCreate", async (message) => {
         message.author.bot ||
         !message.guild ||
         !message.content.toLowerCase().startsWith(client.config.prefix)
-    )
-        return;
+    ) return;
 
     const [cmd, ...args] = message.content
         .slice(client.config.prefix.length)


### PR DESCRIPTION
Put `return;` after the `)` because newbies won't be confused about what does this `return;` do, and also looks for neater.